### PR TITLE
Update lending.py for https://openlibrary.org/random to Work

### DIFF
--- a/openlibrary/core/lending.py
+++ b/openlibrary/core/lending.py
@@ -208,7 +208,7 @@ def get_random_available_ia_edition():
     """uses archive advancedsearch to raise a random book"""
     try:
         url = ("http://%s/advancedsearch.php?q=_exists_:openlibrary_work"
-               "+AND+(lending___available_to_borrow OR lending___available_to_browse)"
+               "+AND+(lending___available_to_borrow:true OR lending___available_to_browse:true)"
                "&fl=identifier,openlibrary_edition"
                "&output=json&rows=1&sort[]=random" % (config_bookreader_host))
         response = requests.get(url, timeout=config_http_request_timeout)


### PR DESCRIPTION
The Query is Updated to
https://archive.org/advancedsearch.php?q=_exists_:openlibrary_work+AND+(lending___available_to_borrow:true%20OR%20lending___available_to_browse:true)&fl=identifier,openlibrary_edition&output=json&rows=1&sort[]=random

namely adding :true after lending___available_to_browse and lending___available_to_borrow.

<!-- What issue does this PR close? -->
Closes #4553